### PR TITLE
Making the Python and MATLAB version compatible and adding tests

### DIFF
--- a/matlab_octave/eeg_picard.m
+++ b/matlab_octave/eeg_picard.m
@@ -1,0 +1,8 @@
+function EEG = eeg_picard(EEG, varargin)
+
+[~, EEG.icaweights] = picard( double(EEG.data), 'python_defaults', true, 'verbose', true, 'mode', 'standard', varargin{:});
+EEG.icasphere = eye(size(EEG.icaweights, 2));
+EEG.icawinv = pinv(EEG.icaweights);
+EEG.icachansind = 1:size(EEG.icaweights, 2);
+EEG.icaact = EEG.icaweights * EEG.icasphere * EEG.data(EEG.icachansind, :);
+EEG.icaact = reshape(EEG.icaact, size(EEG.data, 1), EEG.pnts, EEG.trials);

--- a/matlab_octave/whitening.m
+++ b/matlab_octave/whitening.m
@@ -1,11 +1,17 @@
 function [Z, W] = whitening(Y, mode, n_components)
     % Whitens the data Y using sphering or pca
     R = (Y * Y') / size(Y, 2);
-    [U, D, tmp] = svd(R);
+    [U, D, ~] = svd(R);
     D = diag(D);
     if strcmp(mode, 'pca')
         W = diag(1. ./ sqrt(D)) * U';
         W = W(1:n_components, :);
+        for i = 1:size(W,1)
+            [~, j] = max(abs(W(i,:)));
+            if W(i,j) < 0
+                W(i,:) = -W(i,:);
+            end
+        end
         Z = W * Y;
     elseif strcmp(mode, 'sph')
         W = U *  diag(1. ./ sqrt(D)) * U';

--- a/picard/solver.py
+++ b/picard/solver.py
@@ -174,6 +174,13 @@ def picard(X, fun='tanh', n_components=None, ortho=True, extended=None,
         K = (u / d).T[:n_components]
         del u, d
         K *= np.sqrt(p)
+        
+        # enforce fixed‐sign for consistency with MATLAB code
+        for i in range(K.shape[0]):
+            j = np.argmax(np.abs(K[i]))
+            if K[i, j] < 0:
+                K[i] = -K[i] # inverts the sign of the i-th row of the matrix K
+                    
         X1 = np.dot(K, X1)
         covariance = np.eye(n_components)  # For extended
     else:

--- a/tests/README_TEST.md
+++ b/tests/README_TEST.md
@@ -1,0 +1,5 @@
+Comparing MATLAB and Python versions
+
+These tests are designed to ensure that the MATLAB and Python versions produce reproducible results for the standard version of the algorithm. The orthogonal (FastICA) version is not covered by these tests. Each test compares specific functionality between MATLAB and its corresponding Python implementation. Some tests require an EEG data file that is not included here, but may be downloaded at: https://github.com/sccn/eegprep/blob/develop/data/eeglab_data_with_ica_tmp.set
+
+A. Delorme - June 2025

--- a/tests/test_picard_eeg.m
+++ b/tests/test_picard_eeg.m
@@ -1,0 +1,3 @@
+EEG = pop_loadset('eeglab_data_with_ica_tmp.set');
+
+EEG = eeg_picard(EEG);

--- a/tests/test_picard_eeg.py
+++ b/tests/test_picard_eeg.py
@@ -1,0 +1,8 @@
+from eegprep import pop_loadset
+from picard import picard
+import numpy as np
+from scipy.io import loadmat
+
+EEG = loadmat('tests/eeglab_data_with_ica_tmp.set');
+
+picard(EEG['data'].astype(np.float64), ortho=False, verbose=True, whiten=True, random_state=5489) #, w_init=np.eye(32));

--- a/tests/test_picard_eeg_core.m
+++ b/tests/test_picard_eeg_core.m
@@ -1,0 +1,3 @@
+EEG = pop_loadset('eeglab_data_with_ica_tmp.set');
+
+EEG = eeg_picard(EEG, 'w_init', eye(32));

--- a/tests/test_picard_eeg_core.py
+++ b/tests/test_picard_eeg_core.py
@@ -1,0 +1,9 @@
+from eegprep import pop_loadset
+from eegprep.eeg_picard import eeg_picard
+import numpy as np
+from scipy.io import loadmat
+
+# EEG = pop_loadset('tests/eeglab_data_with_ica_tmp.set');
+EEG = loadmat('tests/eeglab_data_with_ica_tmp.set');
+
+EEG = eeg_picard(EEG, ortho=False, verbose=True, whiten=True) #, w_init=np.eye(32));

--- a/tests/test_picard_py_vs_mat.m
+++ b/tests/test_picard_py_vs_mat.m
@@ -1,0 +1,18 @@
+clear
+rng(0); % for reproducibility
+
+% Run Python version first so it saves the data.mat array
+addpath('../matlab_octave/')
+
+% load the same data
+try
+   d = load('picard_data.mat','X','A');
+catch
+   error('Run the python program first');
+end
+X = d.X;
+A = d.A;
+% run MATLAB Picard
+[Y_mat, W_mat] = picard_standard(X, 10, 200, 2, 1e-6, 0.01, 10, true, 'logcosh', 'pythonlike');
+%[Y_mat, W_mat] = picard_standard3(X, 10, 200, 2, 1e-6, 0.01, 10, true);
+fprintf('MATLAB finished\n');

--- a/tests/test_picard_py_vs_mat.py
+++ b/tests/test_picard_py_vs_mat.py
@@ -1,0 +1,34 @@
+import numpy as np
+from scipy.io import savemat, loadmat
+from picard._core_picard import core_picard
+
+def amari_index(W_true, W_est):
+    P = W_est @ np.linalg.inv(W_true)
+    C = np.abs(P)
+    row_sum = np.sum(C, axis=1, keepdims=True)
+    col_sum = np.sum(C, axis=0, keepdims=True)
+    r = np.sum((C / row_sum - 1/P.shape[1])**2)
+    c = np.sum((C / col_sum - 1/P.shape[0])**2)
+    return (r + c) / (2 * P.shape[0])
+
+# fixed seed for reproducibility
+np.random.seed(0)
+
+# generate sources
+N, T = 5, 10000
+S = np.random.laplace(size=(N, T))
+
+# random mixing
+A = np.random.randn(N, N)
+X = A @ S
+
+# save data for MATLAB
+savemat('picard_data.mat', {'X': X, 'A': A})
+
+# run Python Picard
+# from threadpoolctl import threadpool_limits
+#with threadpool_limits(limits=1, user_api="blas"):
+Y_py, W_py, info_py = core_picard(X.copy(), ortho=False, extended=False,
+                                  max_iter=200, tol=1e-6, m=10,
+                                  lambda_min=0.01, ls_tries=10, verbose=True)
+print('Python converged in', info_py['n_iterations'], 'iterations')

--- a/tests/test_random_norm.m
+++ b/tests/test_random_norm.m
@@ -1,0 +1,18 @@
+
+% Seed MT19937 and force the polar Box–Muller method
+s = RandStream('mt19937ar', 'Seed', 5489, 'NormalTransform', 'Polar');
+RandStream.setGlobalStream(s);
+
+% Generate and transpose so positions match NumPy's row-major layout
+n_components = 11;
+w_init = randn(ceil(n_components*n_components/2)*2,1);
+w_init = w_init(:);
+
+w_initTmp = w_init(1:2:end);
+w_init(1:2:end) = w_init(2:2:end);
+w_init(2:2:end) = w_initTmp;
+
+w_init = reshape(w_init(1:n_components*n_components), n_components, n_components)';
+
+
+w_init

--- a/tests/test_random_norm.py
+++ b/tests/test_random_norm.py
@@ -1,0 +1,20 @@
+import numpy as np
+import numbers
+from picard._tools import check_random_state
+
+random_state = check_random_state(5489)
+n_components = 11
+w_init = np.asarray(random_state.normal(size=(n_components,
+                    n_components)), dtype='float64')
+# print full matrix with 10 decimals, all rows and columns
+np.set_printoptions(precision=10)
+
+# print all rows and columns of w_init as a MATLAB matrix
+print('[')
+for i in range(n_components):
+    for j in range(n_components):
+        print(w_init[i, j], end=' ')
+    print(';')
+print(']')
+
+

--- a/tests/test_whitening.m
+++ b/tests/test_whitening.m
@@ -1,0 +1,5 @@
+EEG = pop_loadset('eeglab_data_with_ica_tmp.set');
+
+[~,whitening_matrix] = whitening(double(EEG.data), 'pca', EEG.nbchan);
+
+whitening_matrix(1:6,1:6)

--- a/tests/test_whitening.py
+++ b/tests/test_whitening.py
@@ -1,0 +1,28 @@
+from eegprep import pop_loadset
+import numpy as np
+from scipy import linalg
+
+def whitening(X1, n_components):
+    n, p = X1.shape
+    u, d, _ = linalg.svd(X1, full_matrices=False)
+    # build K = (u / d).T[:n_components] * sqrt(p)
+    K = (u / d).T[:n_components]
+    K *= np.sqrt(p)
+
+    # enforce fixed‐sign: make the max‐abs entry in each row positive
+    for i in range(K.shape[0]):
+        j = np.argmax(np.abs(K[i]))
+        if K[i, j] < 0:
+            K[i] = -K[i]
+
+    # whiten the data
+    X1 = K.dot(X1)
+    covariance = np.eye(n_components)  # for extended
+
+    return X1, K, covariance
+
+EEG = pop_loadset('tests/eeglab_data_with_ica_tmp.set');
+
+X1, K, covariance = whitening(EEG['data'].astype(np.float64), 32)
+print(K[0:6,0:6])
+print(covariance[0:6,0:6])


### PR DESCRIPTION
**Changes in Python code:**
- Signs of the eigenvectors (which are arbitrary) are made predictable

**Changes to MATLAB code:**
- Adding options so that it is possible to get results compatible with Python

**Tests result images:**
- Compare_Python_MATLAB_weights: compare side by side Python (right) and MATLAB (left) weights when using Python compatibility mode
- MATLAB_backward_compatibility: show that the output when using the default option remains the same for both ortho and standard options when compared to the old code (left)
- Compare_Python_MATLAB: compare side by side the output of the new test functions. The last one differs slightly due to the limit of numerical accuracy.

![Compare_Python_MATLAB_weights](https://github.com/user-attachments/assets/3783c922-bc8d-4348-b122-e53fd5af530e)
![MATLAB_backward_compatibility](https://github.com/user-attachments/assets/2682efa1-0522-4b2c-abed-2635a78541b0)
![Compare_Python_MATLAB](https://github.com/user-attachments/assets/76c208ba-db86-4d7d-9506-ca56acd6e73c)
