### PR TITLE
Fix FloatingPointError with NumPy 2.x due to overflow in line search

### DIFF
--- a/picard/_core_picard.py
+++ b/picard/_core_picard.py
@@ -198,14 +198,15 @@ def _line_search(Y, W, density, direction, signs, current_loss, ls_tries,
     if current_loss is None:
         current_loss = _loss(Y, W, density, signs, ortho, extended)
     for _ in range(ls_tries):
-        if ortho:
-            transform = expm(alpha * direction)
-        else:
-            transform = np.eye(N) + alpha * direction
-        Y_new = np.dot(transform, Y)
-        W_new = np.dot(transform, W)
-        new_loss = _loss(Y_new, W_new, density, signs, ortho, extended)
-        if new_loss < current_loss:
+        with np.errstate(over='ignore', invalid='ignore'):
+            if ortho:
+                transform = expm(alpha * direction)
+            else:
+                transform = np.eye(N) + alpha * direction
+            Y_new = np.dot(transform, Y)
+            W_new = np.dot(transform, W)
+            new_loss = _loss(Y_new, W_new, density, signs, ortho, extended)
+        if np.isfinite(new_loss) and new_loss < current_loss:
             return True, Y_new, W_new, new_loss, alpha * direction
         alpha /= 2.
     else:

--- a/picard/solver.py
+++ b/picard/solver.py
@@ -209,8 +209,7 @@ def picard(X, fun='tanh', n_components=None, ortho=True, extended=None,
               'verbose': verbose, 'ortho': ortho, 'extended': extended,
               'covariance': covariance}
 
-    with np.errstate(over='raise', invalid='raise'):
-        Y, W, infos = core_picard(X1, **kwargs)
+    Y, W, infos = core_picard(X1, **kwargs)
 
     del X1
     W = np.dot(W, w_init)

--- a/picard/tests/test_solver.py
+++ b/picard/tests/test_solver.py
@@ -272,6 +272,31 @@ def test_no_regression(mode, ortho):
     assert n_mean < nb_mean, err_msg % (mode, ortho, n_mean, nb_mean)
 
 
+def test_line_search_overflow():
+    """Test that _line_search handles expm overflow gracefully.
+
+    Regression test for NumPy 2.x compatibility: when the L-BFGS direction
+    has large entries, expm overflows internally. The line search should
+    reject such steps instead of crashing.
+    """
+    from picard._core_picard import _line_search
+
+    N, T = 5, 1000
+    rng = np.random.RandomState(42)
+    Y = rng.randn(N, T)
+    W = np.eye(N)
+    density = Tanh()
+    signs = np.ones(N)
+
+    # A direction with large diagonal causes expm to overflow internally
+    direction = np.eye(N) * 800
+    with np.errstate(over='raise', invalid='raise'):
+        converged, _, _, _, _ = _line_search(
+            Y, W, density, direction, signs, None, 10, False, True, False
+        )
+    assert not converged
+
+
 def test_amari_distance():
     p = 3
     rng = np.random.RandomState(0)


### PR DESCRIPTION
NumPy 2.x propagates np.errstate into compiled C/Cython code, so np.errstate(over='raise') now causes expm and slogdet to raise FloatingPointError on overflow during trial line-search steps.

Remove the overly aggressive errstate wrapper in picard(), and instead handle overflow gracefully in _line_search: suppress overflow warnings during trial computations and reject non-finite losses via np.isfinite.

Hopefully this fixes #68 