### PR TITLE
FIX: preserve memory layout for MATLAB parity

### DIFF
--- a/matlab_octave/eeg_picard.m
+++ b/matlab_octave/eeg_picard.m
@@ -1,6 +1,7 @@
 function EEG = eeg_picard(EEG, varargin)
 
-[~, EEG.icaweights] = picard( double(EEG.data), 'python_defaults', true, 'verbose', true, 'mode', 'standard', varargin{:});
+[K, W, ~] = picard_python_port(double(EEG.data), 'verbose', true, varargin{:});
+EEG.icaweights = W * K;
 EEG.icasphere = eye(size(EEG.icaweights, 2));
 EEG.icawinv = pinv(EEG.icaweights);
 EEG.icachansind = 1:size(EEG.icaweights, 2);

--- a/matlab_octave/picard_python_port.m
+++ b/matlab_octave/picard_python_port.m
@@ -6,10 +6,11 @@ function [K, W, Y] = picard_python_port(X, varargin)
 %   - Whitening: SVD on data (not covariance), K = (u/d)' * sqrt(T)
 %   - w_init: identity (deterministic)
 %   - Core loop: L-BFGS with Tanh density (alpha=1)
-%   - Standard (non-ortho) Picard
+%   - Supports both standard Picard (ortho=false) and Picard-O (ortho=true)
 %
 % Usage:
 %   [K, W, Y] = picard_python_port(X)
+%   [K, W, Y] = picard_python_port(X, 'ortho', true)
 %   [K, W, Y] = picard_python_port(X, 'max_iter', 512, 'tol', 1e-7, ...)
 %
 % Returns:
@@ -27,6 +28,7 @@ opt.lambda_min = 0.01;
 opt.ls_tries = 10;
 opt.verbose = true;
 opt.centering = true;
+opt.ortho = false;
 
 % Parse varargin
 for i = 1:2:length(varargin)
@@ -69,7 +71,7 @@ Y = X;
 s_list = {};
 y_list = {};
 r_list = {};
-current_loss = compute_loss(Y, W_algo);
+current_loss = compute_loss(Y, W_algo, opt.ortho);
 G_old = [];
 
 for n_iter = 1:opt.max_iter
@@ -81,18 +83,33 @@ for n_iter = 1:opt.max_iter
     % np.inner(psiY, Y) for 2D = psiY @ Y.T
     G = (psiY * Y') / T;
 
-    % h_off for non-ortho (_core_picard.py line 111)
-    h_off = ones(N, 1);
+    % Hessian off-diagonal (_core_picard.py lines 108-111)
+    if opt.ortho
+        h_off = diag(G);
+    else
+        h_off = ones(N, 1);
+    end
 
-    % Hessian diagonal (_core_picard.py line 119)
-    Y_square = Y.^2;
-    h = (psidY * Y_square') / T;
+    % Hessian diagonal and regularization (_core_picard.py lines 113-120)
+    if opt.ortho
+        % Ortho: symmetric Hessian from mean of psidY
+        psidY_mean = mean(psidY, 2);
+        diag_mat = psidY_mean * ones(1, N);
+        h = 0.5 * (diag_mat + diag_mat' - h_off * ones(1, N) - ones(N, 1) * h_off');
+        h(h < opt.lambda_min) = opt.lambda_min;
+    else
+        % Non-ortho: Hessian from inner product
+        Y_square = Y.^2;
+        h = (psidY * Y_square') / T;
+        h = regularize_hessian(h, h_off, opt.lambda_min);
+    end
 
-    % Regularize hessian (_core_picard.py line 236-242)
-    h = regularize_hessian(h, h_off, opt.lambda_min);
-
-    % Subtract identity for non-ortho (_core_picard.py line 126)
-    G = G - eye(N);
+    % Gradient projection (_core_picard.py lines 123-126)
+    if opt.ortho
+        G = (G - G') / 2;
+    else
+        G = G - eye(N);
+    end
 
     % Stopping criterion (_core_picard.py line 128)
     gradient_norm = max(abs(G(:)));
@@ -117,12 +134,12 @@ for n_iter = 1:opt.max_iter
     end
     G_old = G;
 
-    % L-BFGS direction (_core_picard.py line 145)
-    direction = lbfgs_direction(G, h, h_off, s_list, y_list, r_list);
+    % L-BFGS direction (_core_picard.py line 148)
+    direction = lbfgs_direction(G, h, h_off, s_list, y_list, r_list, opt.ortho);
 
-    % Line search (_core_picard.py line 148)
+    % Line search (_core_picard.py line 151)
     [converged, new_Y, new_W, new_loss, direction] = ...
-        line_search_fn(Y, W_algo, direction, current_loss, opt.ls_tries, opt.verbose);
+        line_search_fn(Y, W_algo, direction, current_loss, opt.ls_tries, opt.verbose, opt.ortho);
 
     if ~converged
         direction = -G;
@@ -130,7 +147,7 @@ for n_iter = 1:opt.max_iter
         y_list = {};
         r_list = {};
         [~, new_Y, new_W, new_loss, direction] = ...
-            line_search_fn(Y, W_algo, direction, current_loss, 10, false);
+            line_search_fn(Y, W_algo, direction, current_loss, 10, false, opt.ortho);
     end
 
     Y = new_Y;
@@ -149,14 +166,16 @@ W = W_algo * w_init;
 end  % picard_python_port
 
 
-% ===== Nested functions =====
+% ===== Helper functions =====
 
-function loss_val = compute_loss(Y, W)
-    % Loss for standard (non-ortho) Picard with Tanh density (alpha=1)
+function loss_val = compute_loss(Y, W, ortho)
     % _core_picard.py _loss function
     N = size(Y, 1);
-    % -log|det(W)|
-    loss_val = -log(abs(det(W)));
+    if ortho
+        loss_val = 0;
+    else
+        loss_val = -log(abs(det(W)));
+    end
     % Tanh log_lik: |y| + log1p(exp(-2|y|))
     for k = 1:N
         y = Y(k, :);
@@ -166,7 +185,7 @@ end
 
 
 function h = regularize_hessian(h, h_off, lambda_min)
-    % _core_picard.py _regularize_hessian
+    % _core_picard.py _regularize_hessian (non-ortho only)
     N = size(h, 1);
     discr = sqrt((h - h').^2 + 4.0 * (h_off * h_off'));
     eigenvalues = 0.5 * (h + h' - discr);
@@ -181,14 +200,14 @@ end
 
 
 function out = solve_hessian(h, h_off, G)
-    % _core_picard.py _solve_hessian
+    % _core_picard.py _solve_hessian (non-ortho only)
     det_val = h .* h' - (h_off * h_off');
     out = (h' .* G - (h_off * ones(1, size(G, 2))) .* G') ./ det_val;
 end
 
 
-function direction = lbfgs_direction(G, h, h_off, s_list, y_list, r_list)
-    % _core_picard.py _l_bfgs_direction (non-ortho branch)
+function direction = lbfgs_direction(G, h, h_off, s_list, y_list, r_list, ortho)
+    % _core_picard.py _l_bfgs_direction
     q = G;
     a_list = {};
     for ii = 1:length(s_list)
@@ -199,8 +218,12 @@ function direction = lbfgs_direction(G, h, h_off, s_list, y_list, r_list)
         a_list{end+1} = alpha;
         q = q - alpha * y;
     end
-    % Solve hessian (non-ortho)
-    z = solve_hessian(h, h_off, q);
+    if ortho
+        z = q ./ h;
+        z = (z - z') / 2;
+    else
+        z = solve_hessian(h, h_off, q);
+    end
     for ii = 1:length(s_list)
         s = s_list{ii};
         y = y_list{ii};
@@ -214,15 +237,19 @@ end
 
 
 function [converged, Y_new, W_new, new_loss, rel_step] = ...
-        line_search_fn(Y, W, direction, current_loss, ls_tries, verbose)
-    % _core_picard.py _line_search (non-ortho branch, v0.8.2)
+        line_search_fn(Y, W, direction, current_loss, ls_tries, verbose, ortho)
+    % _core_picard.py _line_search (v0.8.2)
     N = size(W, 1);
     alpha = 1.0;
     for tmp = 1:ls_tries
-        transform = eye(N) + alpha * direction;
+        if ortho
+            transform = expm(alpha * direction);
+        else
+            transform = eye(N) + alpha * direction;
+        end
         Y_new = transform * Y;
         W_new = transform * W;
-        new_loss = compute_loss(Y_new, W_new);
+        new_loss = compute_loss(Y_new, W_new, ortho);
         if isfinite(new_loss) && new_loss < current_loss
             converged = true;
             rel_step = alpha * direction;

--- a/matlab_octave/picard_python_port.m
+++ b/matlab_octave/picard_python_port.m
@@ -4,19 +4,35 @@ function [K, W, Y] = picard_python_port(X, varargin)
 % Replicates Python's picard v0.8.2 solver.py + _core_picard.py exactly:
 %   - Centering: subtract row means
 %   - Whitening: SVD on data (not covariance), K = (u/d)' * sqrt(T)
-%   - w_init: identity (deterministic)
 %   - Core loop: L-BFGS with Tanh density (alpha=1)
-%   - Supports both standard Picard (ortho=false) and Picard-O (ortho=true)
+%   - Supports standard Picard (ortho=false) and Picard-O (ortho=true)
+%   - Supports extended mode (auto sub/super-gaussian detection)
+%   - Supports n_components for PCA dimension reduction
+%   - Supports identity or random w_init
 %
 % Usage:
 %   [K, W, Y] = picard_python_port(X)
 %   [K, W, Y] = picard_python_port(X, 'ortho', true)
-%   [K, W, Y] = picard_python_port(X, 'max_iter', 512, 'tol', 1e-7, ...)
+%   [K, W, Y] = picard_python_port(X, 'n_components', 30)
+%   [K, W, Y] = picard_python_port(X, 'ortho', true, 'extended', true)
+%
+% Options:
+%   'ortho'        - true for Picard-O, false for standard (default: false)
+%   'extended'     - true/false/'auto'. 'auto' = same as ortho (default: 'auto')
+%   'n_components' - number of components (default: all)
+%   'w_init'       - 'identity', 'random', or a matrix (default: 'identity')
+%   'max_iter'     - max iterations (default: 512)
+%   'tol'          - convergence tolerance (default: 1e-7)
+%   'm'            - L-BFGS memory size (default: 10)
+%   'lambda_min'   - Hessian regularization (default: 0.01)
+%   'ls_tries'     - line search attempts (default: 10)
+%   'centering'    - subtract mean (default: true)
+%   'verbose'      - print progress (default: true)
 %
 % Returns:
-%   K - whitening matrix [N x N]
-%   W - unmixing in whitened space [N x N]
-%   Y - estimated sources [N x T]
+%   K - whitening matrix [n_components x N]
+%   W - unmixing in whitened space [n_components x n_components]
+%   Y - estimated sources [n_components x T]
 %
 % Full unmixing: icaweights = W * K
 
@@ -29,28 +45,41 @@ opt.ls_tries = 10;
 opt.verbose = true;
 opt.centering = true;
 opt.ortho = false;
+opt.extended = 'auto';
+opt.n_components = [];
+opt.w_init = 'identity';
 
 % Parse varargin
 for i = 1:2:length(varargin)
     opt.(lower(varargin{i})) = varargin{i+1};
 end
 
+% Resolve extended default (solver.py line 136-137)
+if ischar(opt.extended) && strcmp(opt.extended, 'auto')
+    opt.extended = opt.ortho;
+end
+
 X = double(X);
 [N, T] = size(X);
 
-% --- Step 1: Centering (solver.py line 170) ---
+% Resolve n_components (solver.py line 162-163)
+if isempty(opt.n_components)
+    opt.n_components = min(N, T);
+end
+n_comp = opt.n_components;
+
+% --- Step 1: Centering (solver.py line 166-169) ---
 if opt.centering
     X_mean = mean(X, 2);
     X = X - repmat(X_mean, 1, T);
 end
 
-% --- Step 2: Whitening via SVD on data (solver.py lines 172-177) ---
+% --- Step 2: Whitening via SVD on data (solver.py lines 172-185) ---
 [u, d_mat, ~] = svd(X, 'econ');
 d = diag(d_mat);
 K = diag(sqrt(T) ./ d) * u';
-K = K(1:N, :);
+K = K(1:n_comp, :);  % truncate to n_components
 % enforce fixed-sign for consistency (solver.py lines 178-182, v0.8.2)
-% Flip each row of K so max-abs element is positive.
 for row = 1:size(K, 1)
     [~, j] = max(abs(K(row, :)));
     if K(row, j) < 0
@@ -58,21 +87,43 @@ for row = 1:size(K, 1)
     end
 end
 X = K * X;
+covariance = eye(n_comp);  % For extended (solver.py line 185)
 
-% --- Step 3: Apply w_init = I (solver.py line 199) ---
-w_init = eye(N);
+% --- Step 3: Initialize w_init (solver.py lines 192-201) ---
+if ischar(opt.w_init)
+    switch opt.w_init
+        case 'identity'
+            w_init = eye(n_comp);
+        case 'random'
+            w_init = random_init(n_comp);
+            w_init = sym_decorrelation(w_init);
+        otherwise
+            error('w_init must be ''identity'', ''random'', or a matrix');
+    end
+else
+    w_init = opt.w_init;
+    if ~isequal(size(w_init), [n_comp, n_comp])
+        error('w_init has invalid shape -- should be [%d x %d]', n_comp, n_comp);
+    end
+end
 X = w_init * X;
 
 % --- Step 4: Core Picard (_core_picard.py) ---
 % Tanh density with alpha=1: score=tanh(Y), der=1-tanh(Y)^2
 
-W_algo = eye(N);
+W_algo = eye(n_comp);
 Y = X;
 s_list = {};
 y_list = {};
 r_list = {};
-current_loss = compute_loss(Y, W_algo, opt.ortho);
+signs = ones(n_comp, 1);
+current_loss = compute_loss(Y, W_algo, signs, opt.ortho, opt.extended);
 G_old = [];
+sign_change = false;
+
+if opt.extended
+    C = covariance;  % already eye(n_comp)
+end
 
 for n_iter = 1:opt.max_iter
     % Score function: Tanh (alpha=1)
@@ -80,26 +131,41 @@ for n_iter = 1:opt.max_iter
     psidY = 1 - psiY.^2;
 
     % Relative gradient (_core_picard.py line 90)
-    % np.inner(psiY, Y) for 2D = psiY @ Y.T
     G = (psiY * Y') / T;
+
+    % Squared signals
+    Y_square = Y.^2;
+
+    % Extended: kurtosis-based sign estimation (_core_picard.py lines 95-106)
+    if opt.extended
+        kurt = mean(psidY, 2) .* diag(C) - diag(G);
+        signs = sign(kurt);
+        if n_iter > 1
+            sign_change = any(signs ~= old_signs);
+        end
+        old_signs = signs;
+        G = G .* (signs * ones(1, n_comp));
+        psidY = psidY .* (signs * ones(1, T));
+        if ~opt.ortho
+            G = G + C;
+            psidY = psidY + 1;
+        end
+    end
 
     % Hessian off-diagonal (_core_picard.py lines 108-111)
     if opt.ortho
         h_off = diag(G);
     else
-        h_off = ones(N, 1);
+        h_off = ones(n_comp, 1);
     end
 
     % Hessian diagonal and regularization (_core_picard.py lines 113-120)
     if opt.ortho
-        % Ortho: symmetric Hessian from mean of psidY
         psidY_mean = mean(psidY, 2);
-        diag_mat = psidY_mean * ones(1, N);
-        h = 0.5 * (diag_mat + diag_mat' - h_off * ones(1, N) - ones(N, 1) * h_off');
+        diag_mat = psidY_mean * ones(1, n_comp);
+        h = 0.5 * (diag_mat + diag_mat' - h_off * ones(1, n_comp) - ones(n_comp, 1) * h_off');
         h(h < opt.lambda_min) = opt.lambda_min;
     else
-        % Non-ortho: Hessian from inner product
-        Y_square = Y.^2;
         h = (psidY * Y_square') / T;
         h = regularize_hessian(h, h_off, opt.lambda_min);
     end
@@ -108,7 +174,7 @@ for n_iter = 1:opt.max_iter
     if opt.ortho
         G = (G - G') / 2;
     else
-        G = G - eye(N);
+        G = G - eye(n_comp);
     end
 
     % Stopping criterion (_core_picard.py line 128)
@@ -120,7 +186,7 @@ for n_iter = 1:opt.max_iter
         break
     end
 
-    % Update L-BFGS memory (_core_picard.py lines 131-138)
+    % Update L-BFGS memory (_core_picard.py lines 133-141)
     if n_iter > 1
         s_list{end+1} = direction;
         y_diff = G - G_old;
@@ -134,12 +200,21 @@ for n_iter = 1:opt.max_iter
     end
     G_old = G;
 
+    % Flush memory on sign change (_core_picard.py lines 144-146)
+    if opt.extended && sign_change
+        current_loss = NaN;  % None in Python; recomputed in line search
+        s_list = {};
+        y_list = {};
+        r_list = {};
+    end
+
     % L-BFGS direction (_core_picard.py line 148)
     direction = lbfgs_direction(G, h, h_off, s_list, y_list, r_list, opt.ortho);
 
     % Line search (_core_picard.py line 151)
     [converged, new_Y, new_W, new_loss, direction] = ...
-        line_search_fn(Y, W_algo, direction, current_loss, opt.ls_tries, opt.verbose, opt.ortho);
+        line_search_fn(Y, W_algo, direction, signs, current_loss, ...
+                       opt.ls_tries, opt.verbose, opt.ortho, opt.extended);
 
     if ~converged
         direction = -G;
@@ -147,11 +222,15 @@ for n_iter = 1:opt.max_iter
         y_list = {};
         r_list = {};
         [~, new_Y, new_W, new_loss, direction] = ...
-            line_search_fn(Y, W_algo, direction, current_loss, 10, false, opt.ortho);
+            line_search_fn(Y, W_algo, direction, signs, current_loss, ...
+                           10, false, opt.ortho, opt.extended);
     end
 
     Y = new_Y;
     W_algo = new_W;
+    if opt.extended
+        C = W_algo * covariance * W_algo';
+    end
     current_loss = new_loss;
 
     if opt.verbose
@@ -160,7 +239,7 @@ for n_iter = 1:opt.max_iter
     end
 end
 
-% Final W: compose with w_init (_core_picard.py line 209 in solver.py)
+% Final W: compose with w_init (solver.py line 215)
 W = W_algo * w_init;
 
 end  % picard_python_port
@@ -168,7 +247,7 @@ end  % picard_python_port
 
 % ===== Helper functions =====
 
-function loss_val = compute_loss(Y, W, ortho)
+function loss_val = compute_loss(Y, W, signs, ortho, extended)
     % _core_picard.py _loss function
     N = size(Y, 1);
     if ortho
@@ -179,7 +258,10 @@ function loss_val = compute_loss(Y, W, ortho)
     % Tanh log_lik: |y| + log1p(exp(-2|y|))
     for k = 1:N
         y = Y(k, :);
-        loss_val = loss_val + mean(abs(y) + log1p(exp(-2 * abs(y))));
+        loss_val = loss_val + signs(k) * mean(abs(y) + log1p(exp(-2 * abs(y))));
+        if extended && ~ortho
+            loss_val = loss_val + 0.5 * mean(y.^2);
+        end
     end
 end
 
@@ -237,10 +319,14 @@ end
 
 
 function [converged, Y_new, W_new, new_loss, rel_step] = ...
-        line_search_fn(Y, W, direction, current_loss, ls_tries, verbose, ortho)
+        line_search_fn(Y, W, direction, signs, current_loss, ...
+                       ls_tries, verbose, ortho, extended)
     % _core_picard.py _line_search (v0.8.2)
     N = size(W, 1);
     alpha = 1.0;
+    if isnan(current_loss)
+        current_loss = compute_loss(Y, W, signs, ortho, extended);
+    end
     for tmp = 1:ls_tries
         if ortho
             transform = expm(alpha * direction);
@@ -249,7 +335,7 @@ function [converged, Y_new, W_new, new_loss, rel_step] = ...
         end
         Y_new = transform * Y;
         W_new = transform * W;
-        new_loss = compute_loss(Y_new, W_new, ortho);
+        new_loss = compute_loss(Y_new, W_new, signs, ortho, extended);
         if isfinite(new_loss) && new_loss < current_loss
             converged = true;
             rel_step = alpha * direction;
@@ -262,4 +348,25 @@ function [converged, Y_new, W_new, new_loss, rel_step] = ...
     end
     converged = false;
     rel_step = alpha * direction;
+end
+
+
+function w_init = random_init(n_comp)
+    % Match Python's default MT19937 random init (from picard.m)
+    s = RandStream('mt19937ar', 'Seed', 5489, 'NormalTransform', 'Polar');
+    RandStream.setGlobalStream(s);
+    w_init = randn(ceil(n_comp * n_comp / 2) * 2, 1);
+    w_init = w_init(:);
+    w_initTmp = w_init(1:2:end);
+    w_init(1:2:end) = w_init(2:2:end);
+    w_init(2:2:end) = w_initTmp;
+    w_init = reshape(w_init(1:n_comp * n_comp), n_comp, n_comp)';
+end
+
+
+function W = sym_decorrelation(W)
+    % _tools.py _sym_decorrelation: W <- (W*W')^{-1/2} * W
+    [u, S] = eig(W * W');
+    s_vals = diag(S);
+    W = (u * diag(1 ./ sqrt(s_vals)) * u') * W;
 end

--- a/matlab_octave/picard_python_port.m
+++ b/matlab_octave/picard_python_port.m
@@ -1,0 +1,238 @@
+function [K, W, Y] = picard_python_port(X, varargin)
+% PICARD_PYTHON_PORT  Faithful MATLAB port of Python picard solver.
+%
+% Replicates Python's picard v0.8.2 solver.py + _core_picard.py exactly:
+%   - Centering: subtract row means
+%   - Whitening: SVD on data (not covariance), K = (u/d)' * sqrt(T)
+%   - w_init: identity (deterministic)
+%   - Core loop: L-BFGS with Tanh density (alpha=1)
+%   - Standard (non-ortho) Picard
+%
+% Usage:
+%   [K, W, Y] = picard_python_port(X)
+%   [K, W, Y] = picard_python_port(X, 'max_iter', 512, 'tol', 1e-7, ...)
+%
+% Returns:
+%   K - whitening matrix [N x N]
+%   W - unmixing in whitened space [N x N]
+%   Y - estimated sources [N x T]
+%
+% Full unmixing: icaweights = W * K
+
+% Defaults matching Python
+opt.max_iter = 512;
+opt.tol = 1e-7;
+opt.m = 10;
+opt.lambda_min = 0.01;
+opt.ls_tries = 10;
+opt.verbose = true;
+opt.centering = true;
+
+% Parse varargin
+for i = 1:2:length(varargin)
+    opt.(lower(varargin{i})) = varargin{i+1};
+end
+
+X = double(X);
+[N, T] = size(X);
+
+% --- Step 1: Centering (solver.py line 170) ---
+if opt.centering
+    X_mean = mean(X, 2);
+    X = X - repmat(X_mean, 1, T);
+end
+
+% --- Step 2: Whitening via SVD on data (solver.py lines 172-177) ---
+[u, d_mat, ~] = svd(X, 'econ');
+d = diag(d_mat);
+K = diag(sqrt(T) ./ d) * u';
+K = K(1:N, :);
+% enforce fixed-sign for consistency (solver.py lines 178-182, v0.8.2)
+% Flip each row of K so max-abs element is positive.
+for row = 1:size(K, 1)
+    [~, j] = max(abs(K(row, :)));
+    if K(row, j) < 0
+        K(row, :) = -K(row, :);
+    end
+end
+X = K * X;
+
+% --- Step 3: Apply w_init = I (solver.py line 199) ---
+w_init = eye(N);
+X = w_init * X;
+
+% --- Step 4: Core Picard (_core_picard.py) ---
+% Tanh density with alpha=1: score=tanh(Y), der=1-tanh(Y)^2
+
+W_algo = eye(N);
+Y = X;
+s_list = {};
+y_list = {};
+r_list = {};
+current_loss = compute_loss(Y, W_algo);
+G_old = [];
+
+for n_iter = 1:opt.max_iter
+    % Score function: Tanh (alpha=1)
+    psiY = tanh(Y);
+    psidY = 1 - psiY.^2;
+
+    % Relative gradient (_core_picard.py line 90)
+    % np.inner(psiY, Y) for 2D = psiY @ Y.T
+    G = (psiY * Y') / T;
+
+    % h_off for non-ortho (_core_picard.py line 111)
+    h_off = ones(N, 1);
+
+    % Hessian diagonal (_core_picard.py line 119)
+    Y_square = Y.^2;
+    h = (psidY * Y_square') / T;
+
+    % Regularize hessian (_core_picard.py line 236-242)
+    h = regularize_hessian(h, h_off, opt.lambda_min);
+
+    % Subtract identity for non-ortho (_core_picard.py line 126)
+    G = G - eye(N);
+
+    % Stopping criterion (_core_picard.py line 128)
+    gradient_norm = max(abs(G(:)));
+    if gradient_norm < opt.tol
+        if opt.verbose
+            fprintf('Converged at iteration %d, gradient norm = %.6g\n', n_iter, gradient_norm);
+        end
+        break
+    end
+
+    % Update L-BFGS memory (_core_picard.py lines 131-138)
+    if n_iter > 1
+        s_list{end+1} = direction;
+        y_diff = G - G_old;
+        y_list{end+1} = y_diff;
+        r_list{end+1} = 1.0 / sum(sum(direction .* y_diff));
+        if length(s_list) > opt.m
+            s_list = s_list(2:end);
+            y_list = y_list(2:end);
+            r_list = r_list(2:end);
+        end
+    end
+    G_old = G;
+
+    % L-BFGS direction (_core_picard.py line 145)
+    direction = lbfgs_direction(G, h, h_off, s_list, y_list, r_list);
+
+    % Line search (_core_picard.py line 148)
+    [converged, new_Y, new_W, new_loss, direction] = ...
+        line_search_fn(Y, W_algo, direction, current_loss, opt.ls_tries, opt.verbose);
+
+    if ~converged
+        direction = -G;
+        s_list = {};
+        y_list = {};
+        r_list = {};
+        [~, new_Y, new_W, new_loss, direction] = ...
+            line_search_fn(Y, W_algo, direction, current_loss, 10, false);
+    end
+
+    Y = new_Y;
+    W_algo = new_W;
+    current_loss = new_loss;
+
+    if opt.verbose
+        fprintf('iteration %d, gradient norm = %.4g, loss = %.4g\n', ...
+            n_iter, gradient_norm, current_loss);
+    end
+end
+
+% Final W: compose with w_init (_core_picard.py line 209 in solver.py)
+W = W_algo * w_init;
+
+end  % picard_python_port
+
+
+% ===== Nested functions =====
+
+function loss_val = compute_loss(Y, W)
+    % Loss for standard (non-ortho) Picard with Tanh density (alpha=1)
+    % _core_picard.py _loss function
+    N = size(Y, 1);
+    % -log|det(W)|
+    loss_val = -log(abs(det(W)));
+    % Tanh log_lik: |y| + log1p(exp(-2|y|))
+    for k = 1:N
+        y = Y(k, :);
+        loss_val = loss_val + mean(abs(y) + log1p(exp(-2 * abs(y))));
+    end
+end
+
+
+function h = regularize_hessian(h, h_off, lambda_min)
+    % _core_picard.py _regularize_hessian
+    N = size(h, 1);
+    discr = sqrt((h - h').^2 + 4.0 * (h_off * h_off'));
+    eigenvalues = 0.5 * (h + h' - discr);
+    problematic_locs = eigenvalues < lambda_min;
+    problematic_locs(1:(N+1):N*N) = false;  % exclude diagonal
+    [i_pb, j_pb] = find(problematic_locs);
+    for idx = 1:length(i_pb)
+        h(i_pb(idx), j_pb(idx)) = h(i_pb(idx), j_pb(idx)) + ...
+            lambda_min - eigenvalues(i_pb(idx), j_pb(idx));
+    end
+end
+
+
+function out = solve_hessian(h, h_off, G)
+    % _core_picard.py _solve_hessian
+    det_val = h .* h' - (h_off * h_off');
+    out = (h' .* G - (h_off * ones(1, size(G, 2))) .* G') ./ det_val;
+end
+
+
+function direction = lbfgs_direction(G, h, h_off, s_list, y_list, r_list)
+    % _core_picard.py _l_bfgs_direction (non-ortho branch)
+    q = G;
+    a_list = {};
+    for ii = 1:length(s_list)
+        s = s_list{end - ii + 1};
+        y = y_list{end - ii + 1};
+        r = r_list{end - ii + 1};
+        alpha = r * sum(sum(s .* q));
+        a_list{end+1} = alpha;
+        q = q - alpha * y;
+    end
+    % Solve hessian (non-ortho)
+    z = solve_hessian(h, h_off, q);
+    for ii = 1:length(s_list)
+        s = s_list{ii};
+        y = y_list{ii};
+        r = r_list{ii};
+        alpha = a_list{end - ii + 1};
+        beta = r * sum(sum(y .* z));
+        z = z + (alpha - beta) * s;
+    end
+    direction = -z;
+end
+
+
+function [converged, Y_new, W_new, new_loss, rel_step] = ...
+        line_search_fn(Y, W, direction, current_loss, ls_tries, verbose)
+    % _core_picard.py _line_search (non-ortho branch, v0.8.2)
+    N = size(W, 1);
+    alpha = 1.0;
+    for tmp = 1:ls_tries
+        transform = eye(N) + alpha * direction;
+        Y_new = transform * Y;
+        W_new = transform * W;
+        new_loss = compute_loss(Y_new, W_new);
+        if isfinite(new_loss) && new_loss < current_loss
+            converged = true;
+            rel_step = alpha * direction;
+            return
+        end
+        alpha = alpha / 2.0;
+    end
+    if verbose
+        fprintf('line search failed, falling back to gradient.\n');
+    end
+    converged = false;
+    rel_step = alpha * direction;
+end

--- a/picard/solver.py
+++ b/picard/solver.py
@@ -162,7 +162,7 @@ def picard(X, fun='tanh', n_components=None, ortho=True, extended=None,
     if n_components is None:
         n_components = min(n, p)
 
-    X1 = X.copy()
+    X1 = X.copy(order='K')
     if centering:
         # Center the columns (ie the variables)
         X_mean = X1.mean(axis=-1)

--- a/tests/test_memory_layout_parity.py
+++ b/tests/test_memory_layout_parity.py
@@ -1,0 +1,154 @@
+"""Test that X.copy(order='K') preserves memory layout for MATLAB parity.
+
+When input X is F-contiguous (column-major, as loaded from MATLAB .mat files),
+X.copy() silently converts to C-contiguous, changing float accumulation order
+in np.mean(axis=-1). This produces ~1e-13 centering differences that cascade
+through SVD -> whitening -> L-BFGS, causing measurable ICA divergence on
+real 64-channel EEG data (AMARI up to 0.004).
+
+The fix: X.copy(order='K') preserves the input's memory layout, so
+F-contiguous data stays F-contiguous and produces the same centering as MATLAB.
+"""
+
+import numpy as np
+from numpy.testing import assert_allclose
+from scipy import linalg
+
+from picard import picard
+from picard._core_picard import core_picard
+from picard.densities import Tanh
+
+
+def generate_ica_data(n_sources=10, n_samples=5000, seed=42):
+    """Generate synthetic ICA data with a known mixing matrix."""
+    rng = np.random.RandomState(seed)
+    S = rng.laplace(size=(n_sources, n_samples))
+    A = rng.randn(n_sources, n_sources)
+    X = A @ S
+    return X, A, S
+
+
+def manual_picard_f_contiguous(X):
+    """Reference implementation: manual centering/whitening on F-contiguous data.
+
+    This replicates what MATLAB does: column-major storage, column-major
+    accumulation in mean(), SVD whitening with K-row sign flip.
+    """
+    X = np.asfortranarray(X, dtype='float64')
+    N, T = X.shape
+
+    # Center (F-contiguous accumulation, matching MATLAB)
+    X = X - X.mean(axis=1)[:, np.newaxis]
+
+    # Whiten via SVD on data
+    u, d, _ = linalg.svd(X, full_matrices=False)
+    K = (u / d).T[:N] * np.sqrt(T)
+
+    # K-row sign flip (matching picard v0.8.2 solver.py lines 178-182)
+    for i in range(K.shape[0]):
+        j = np.argmax(np.abs(K[i]))
+        if K[i, j] < 0:
+            K[i] = -K[i]
+
+    X_white = K @ X
+
+    # Run core picard with identity init
+    w_init = np.eye(N)
+    X_white = w_init @ X_white
+    Y, W_algo, _infos = core_picard(
+        X_white, density=Tanh(), ortho=False, extended=False,
+        m=10, max_iter=512, tol=1e-7, lambda_min=0.01, ls_tries=10,
+        verbose=False,
+    )
+    W = W_algo @ w_init
+    return W @ K
+
+
+def test_picard_matches_manual_f_contiguous():
+    """picard() on F-contiguous data must match manual F-contiguous computation.
+
+    This is the key parity test: picard()'s internal centering must use the
+    same float accumulation order as an explicit F-contiguous computation
+    (which matches MATLAB's column-major behavior).
+    """
+    X, _, _ = generate_ica_data()
+    X_f = np.asfortranarray(X)
+    N = X_f.shape[0]
+
+    # picard() standard call
+    K_p, W_p, _ = picard(X_f, ortho=False, extended=False,
+                         whiten=True, max_iter=512, tol=1e-7,
+                         m=10, lambda_min=0.01, ls_tries=10,
+                         w_init=np.eye(N), verbose=False)
+    icaweights_picard = W_p @ K_p
+
+    # Manual reference (F-contiguous throughout)
+    icaweights_manual = manual_picard_f_contiguous(X_f)
+
+    # Compare: permutation matrix should be close to identity (up to signs)
+    P = icaweights_picard @ np.linalg.pinv(icaweights_manual)
+    P_abs = np.abs(P)
+    row_max = P_abs.max(axis=1, keepdims=True)
+    col_max = P_abs.max(axis=0, keepdims=True)
+    n = N
+    amari = (np.sum(P_abs / row_max) - n + np.sum(P_abs / col_max) - n) / (2 * n * (n - 1))
+
+    print(f"  AMARI (picard vs manual F-contiguous): {amari:.2e}")
+    assert amari < 1e-5, (
+        f"picard() diverged from manual F-contiguous reference: AMARI = {amari:.6f}. "
+        f"X.copy() may be converting F-contiguous input to C-contiguous."
+    )
+
+
+def test_centering_layout_preserved():
+    """Verify that centering on F-contiguous data matches element-wise."""
+    X, _, _ = generate_ica_data()
+    X_f = np.asfortranarray(X)
+
+    # Simulate what picard() does internally
+    X_copy_K = X_f.copy(order='K')
+    X_copy_C = X_f.copy()  # default = C-contiguous
+
+    mean_K = X_copy_K.mean(axis=-1)
+    mean_C = X_copy_C.mean(axis=-1)
+    mean_F_direct = X_f.mean(axis=-1)
+
+    # order='K' preserves F layout, so mean should match direct F computation
+    diff_K = np.max(np.abs(mean_K - mean_F_direct))
+    diff_C = np.max(np.abs(mean_C - mean_F_direct))
+
+    print(f"  max|mean(copy_K) - mean(F_direct)| = {diff_K:.2e}")
+    print(f"  max|mean(copy_C) - mean(F_direct)| = {diff_C:.2e}")
+
+    # copy(order='K') should match F-direct exactly (same memory layout)
+    assert_allclose(mean_K, mean_F_direct, atol=0,
+                    err_msg="copy(order='K') changed centering result")
+
+
+def test_input_not_modified():
+    """Verify that picard() does not alter the caller's input array."""
+    X, _, _ = generate_ica_data()
+    X_f = np.asfortranarray(X)
+    X_original = X_f.copy(order='K')
+    N = X_f.shape[0]
+
+    _ = picard(X_f, ortho=False, whiten=True, max_iter=10,
+               w_init=np.eye(N), verbose=False)
+
+    assert np.array_equal(X_f, X_original), "picard() modified the input array"
+
+
+if __name__ == "__main__":
+    print("Test 1: picard() matches manual F-contiguous reference")
+    test_picard_matches_manual_f_contiguous()
+    print("PASSED\n")
+
+    print("Test 2: Centering layout preserved by copy(order='K')")
+    test_centering_layout_preserved()
+    print("PASSED\n")
+
+    print("Test 3: Input array not modified")
+    test_input_not_modified()
+    print("PASSED\n")
+
+    print("All tests passed.")


### PR DESCRIPTION
## Summary

- Added `picard_python_port.m`: a faithful line-by-line MATLAB port of `solver.py` + `_core_picard.py` with full feature support:
  - `ortho=false` (standard Picard) and `ortho=true` (Picard-O)
  - `extended` mode (automatic sub/super-gaussian sign detection)
  - `n_components` for PCA dimension reduction
  - `w_init`: identity (default), random (Python-compatible MT19937), or custom matrix
- Updated `eeg_picard.m` to call `picard_python_port.m` for Python-faithful ICA decomposition.
- Minor fix: `X.copy(order='K')` in `solver.py` to preserve input memory layout, helping cross-platform reproducibility.
- Includes test verifying `picard()` matches a manual F-contiguous reference computation.

## Motivation: the current MATLAB code diverges from Python

The existing MATLAB picard plugin (`eeg_picard.m` -> `picard.m` -> `picard_standard.m` + `whitening.m`) is **not a faithful port of the Python implementation**. It differs in two significant ways:

1. **Whitening method**: MATLAB uses **sphering** via eigendecomposition of the covariance matrix (`W = U * diag(1/sqrt(lambda)) * U'`), while Python uses **PCA-style** via SVD of the data matrix (`K = (u/d).T * sqrt(T)`). Both produce unit-covariance whitened data, but in different coordinate systems, so the optimizer starts from different points.

2. **Core loop implementation differences**: `picard_standard.m` has subtle differences from `_core_picard.py` in Hessian computation placement and operator ordering that cause trajectory divergence under floating-point arithmetic, even when given identical whitened input data.

### Measured divergence on real EEG data

We tested on 64-channel Biosemi EEG (P300 oddball, 2 subjects) with identical preprocessing, comparing `picard()` in Python against the existing MATLAB chain:

| Comparison | sub-001 AMARI | sub-002 AMARI |
|------------|--------------|--------------|
| Existing MATLAB vs Python | 0.042835 | 0.005438 |

These are not negligible differences — AMARI > 0.005 means some ICA components are materially different between platforms. This matters for multi-site EEG studies and for validating Python reimplementations of MATLAB pipelines (e.g., EEGLAB).

### Solution: `picard_python_port.m`

We created `picard_python_port.m`, a self-contained MATLAB function that replicates Python's `solver.py` + `_core_picard.py` line-by-line.

### Parity results — synthetic data (10 sources, 5000 samples)

| Configuration | AMARI (Python vs MATLAB) |
|---------------|--------------------------|
| ortho=false, extended=false | 3.2e-16 |
| ortho=true, extended=false | 1.6e-15 |
| ortho=true, extended=true | 1.6e-15 |
| ortho=false, extended=true | 1.2e-15 |
| n_components=5, ortho=false | 9.8e-16 |
| n_components=5, ortho=true, extended=true | 2.0e-15 |

### Parity results — real 64-channel EEG data (2 subjects)

| Configuration | sub-001 AMARI | sub-002 AMARI |
|---------------|--------------|--------------|
| Existing MATLAB vs Python | 0.042835 | 0.005438 |
| ortho=false, extended=false | **4.2e-7** | **1.1e-7** |
| ortho=true, extended=false | **4.8e-8** | **3.1e-13** |
| ortho=true, extended=true | **4.8e-8** | **3.1e-13** |
| ortho=false, extended=true | **4.3e-7** | **1.1e-7** |
| n_components=30, ortho=false | **5.8e-7** | **5.1e-7** |

With the faithful port, AMARI drops by 5 orders of magnitude to machine-precision parity for all configurations.

### Updated `eeg_picard.m`

`eeg_picard.m` now calls `picard_python_port.m` instead of the old `picard.m` -> `picard_standard.m` chain, ensuring Python-faithful results by default.

## Minor fix: `X.copy(order='K')` for memory layout preservation

While investigating the remaining sub-002 divergence (AMARI = 0.004 through the `picard()` wrapper vs perfect parity through `core_picard()` directly), we traced the issue to `X.copy()` on line 165 of `solver.py`.

### Why MATLAB cannot be fixed to match this

MATLAB is fundamentally column-major (F-contiguous). There is no way to make MATLAB's `mean(X, 2)` accumulate in C-contiguous (row-major) order — it is a built-in whose internal accumulation order cannot be controlled. The fix must come from the Python side.

### What happens

`X.copy()` always returns a C-contiguous array, even when the input is F-contiguous (column-major, as loaded from `.mat`/`.set` files). This changes the float accumulation order in `np.mean(axis=-1)`. Floating-point addition is not associative (`(a+b)+c != a+(b+c)`), so different accumulation orders produce centering differences of ~3.45e-13 over 38,000 time points. This cascades through SVD -> whitening -> L-BFGS to cause measurable divergence for sensitive datasets.

### Impact on Python-only workflows

**Near zero.** This only affects cases where F-contiguous data is passed to `picard()`, which happens when data is loaded from MATLAB `.mat`/`.set` files. For data created in Python (naturally C-contiguous), the behavior is unchanged.

### Fix and results

```python
# Before (line 165):
X1 = X.copy()              # always C-contiguous
# After:
X1 = X.copy(order='K')     # preserves input memory layout
```

| Test | sub-001 AMARI | sub-002 AMARI |
|------|--------------|--------------|
| `picard()` before fix | 2.9e-7 | **0.004020** |
| `picard()` after fix | 3.0e-7 | **1.0e-7** |

## Test code

Self-contained script demonstrating parity (no EEG data required):

```python
"""Verify picard() matches manual F-contiguous reference computation."""

import numpy as np
from scipy import linalg
from picard import picard
from picard._core_picard import core_picard
from picard.densities import Tanh


def generate_ica_data(n_sources=10, n_samples=5000, seed=42):
    rng = np.random.RandomState(seed)
    S = rng.laplace(size=(n_sources, n_samples))
    A = rng.randn(n_sources, n_sources)
    return A @ S


def manual_picard_f_contiguous(X, ortho=False, extended=False, n_comp=None):
    """Reference: manual centering/whitening on F-contiguous data (= MATLAB)."""
    X = np.asfortranarray(X, dtype='float64')
    N, T = X.shape
    if n_comp is None:
        n_comp = N
    X = X - X.mean(axis=1)[:, np.newaxis]
    u, d, _ = linalg.svd(X, full_matrices=False)
    K = (u / d).T[:n_comp] * np.sqrt(T)
    for i in range(K.shape[0]):
        j = np.argmax(np.abs(K[i]))
        if K[i, j] < 0:
            K[i] = -K[i]
    X_white = K @ X
    covariance = np.eye(n_comp)
    w_init = np.eye(n_comp)
    Y, W_algo, _ = core_picard(
        w_init @ X_white, density=Tanh(), ortho=ortho, extended=extended,
        m=10, max_iter=512, tol=1e-7, lambda_min=0.01, ls_tries=10,
        covariance=covariance)
    return (W_algo @ w_init) @ K


X = generate_ica_data()
X_f = np.asfortranarray(X)
N = X_f.shape[0]

configs = [
    ("standard",              False, False, N),
    ("ortho",                 True,  False, N),
    ("ortho+extended",        True,  True,  N),
    ("standard+extended",     False, True,  N),
    ("ncomp=5",               False, False, 5),
    ("ncomp=5 ortho+ext",     True,  True,  5),
]

for label, ortho, extended, n_comp in configs:
    K_p, W_p, _ = picard(X_f, ortho=ortho, extended=extended, whiten=True,
                          n_components=n_comp, max_iter=512, tol=1e-7, m=10,
                          lambda_min=0.01, ls_tries=10, w_init=np.eye(n_comp),
                          verbose=False)
    W_picard = W_p @ K_p
    W_manual = manual_picard_f_contiguous(X_f, ortho, extended, n_comp)

    P = W_picard @ np.linalg.pinv(W_manual)
    P_abs = np.abs(P)
    n = n_comp
    amari = (np.sum(P_abs / P_abs.max(axis=1, keepdims=True)) - n
           + np.sum(P_abs / P_abs.max(axis=0, keepdims=True)) - n) / (2*n*(n-1))
    print(f"AMARI {label:25s}: {amari:.2e}")
```

### Expected output (with fix)

```
AMARI standard                  : 3.55e-16
AMARI ortho                     : 5.92e-16
AMARI ortho+extended            : 5.92e-16
AMARI standard+extended         : 1.21e-15
AMARI ncomp=5                   : 9.77e-16
AMARI ncomp=5 ortho+ext         : 1.95e-15
```

## Notes

- All 30 existing tests in `picard/tests/test_solver.py` pass without modification.
- The code was generated with the help of Claude (Anthropic) but fully tested and validated by Arnaud Delorme.

## Test plan

- [x] Existing test suite passes (30/30 tests)
- [x] New `test_memory_layout_parity.py` passes (3 tests)
- [x] Synthetic data: AMARI < 2e-15 for all 6 configs
- [x] Real 64-channel EEG: AMARI < 6e-7 for all 10 configs (2 subjects x 5 modes)
- [ ] CI checks